### PR TITLE
🔀 merge branch 'feat/teacher' into 'main'

### DIFF
--- a/backend/src/controllers/teacher.controller.js
+++ b/backend/src/controllers/teacher.controller.js
@@ -6,7 +6,7 @@ const teacherService = require('../services/teacher.service');
 // GET /api/teacher/class-list
 exports.getTeacherClassListController = async (req, res) => {
   try {
-    const teacherId = req.user.userId;  // verifyToken에서 저장된 정보 사용
+    const teacherId = req.user.userId;
     const classes = await teacherService.getTeacherClassList(teacherId);
     res.json(classes);
   } catch (err) {

--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -6,7 +6,7 @@ const Class = require('../models/class')
 const Text = require('../models/text');
 const Record = require('../models/record');
 
-// POST /api/text/validate-keyword
+// POST /api/text/keywords/validate
 exports.validateKeyword = (req, res) => {
   const { keyword } = req.body;
 
@@ -103,32 +103,6 @@ exports.testTextConnection = async (req, res) => {
 };
 
 
-// GET /api/text/filter 
-exports.filterText = async (req, res) => {
-  const { keyword, level, userId } = req.query;
-
-  try {
-    let text = await textService.filterText(keyword, level);
-
-    if (!text) {
-      text = await textService.requestGeneration(keyword, level);
-    }
-
-    const userRecord = await textService.checkRecord(userId, text._id);
-
-    if (userRecord) {
-      const externalText = await textService.requestGeneration(keyword, level);
-      return res.status(200).json(externalText);
-    }
-
-    return res.status(200).json(text);
-
-  } catch (error) {
-    return res.status(500).json({ message: 'Failed to filter text.', error });
-  }
-};
-
-
 // POST /api/text/feedback
 exports.saveFeedbackController = async (req, res) => {
   try {
@@ -200,7 +174,7 @@ exports.deleteHighlightController = async (req, res) => {
 };
 
 
-// POST /api/text/check-answer
+// POST /api/text/answers/verify
 exports.checkAnswerController = async (req, res) => {
 
   const { userId } = req.user;
@@ -266,7 +240,7 @@ exports.getUserRecordsController = async (req, res) => {
 };
 
 
-// GET /api/text/:textId
+// GET /api/text/contents/:textId
 exports.getTextByIdController = async (req, res) => {
   try {
     const { textId } = req.params;
@@ -296,7 +270,6 @@ exports.getClassInfoByStudentController = async (req, res) => {
       return res.status(400).json({ message: 'Student is not assigned to any class.' });
     }
 
-    // Class 정보 조회
     const classInfo = await Class.findById(user.class_id);
 
     if (!classInfo) {
@@ -311,5 +284,31 @@ exports.getClassInfoByStudentController = async (req, res) => {
   } catch (error) {
     console.error('Error in getClassInfoByStudentController:', error);
     return res.status(500).json({ message: 'Failed to fetch class info', error: error.message });
+  }
+};
+
+
+// GET /api/text/filter
+exports.filterText = async (req, res) => {
+  const { keyword, level, userId } = req.query;
+
+  try {
+    let text = await textService.filterText(keyword, level);
+
+    if (!text) {
+      text = await textService.requestGeneration(keyword, level);
+    }
+
+    const userRecord = await textService.checkRecord(userId, text._id);
+
+    if (userRecord) {
+      const externalText = await textService.requestGeneration(keyword, level);
+      return res.status(200).json(externalText);
+    }
+
+    return res.status(200).json(text);
+
+  } catch (error) {
+    return res.status(500).json({ message: 'Failed to filter text.', error });
   }
 };

--- a/backend/src/routes/teacher.routes.js
+++ b/backend/src/routes/teacher.routes.js
@@ -5,14 +5,186 @@ const router = express.Router();
 const teacherController = require('../controllers/teacher.controller');
 const { verifyToken } = require('../middleware/auth.middleware');
 
-
+/**
+ * @swagger
+ * /api/teacher/classes:
+ *   get:
+ *     summary: Get the list of classes assigned to the teacher
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of classes
+ *       500:
+ *         description: Server error
+ */
 router.get('/classes', verifyToken, teacherController.getTeacherClassListController);
+
+
+/**
+ * @swagger
+ * /api/teacher/classes/{classId}/students:
+ *   get:
+ *     summary: Get list of students in a class
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: classId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the class
+ *     responses:
+ *       200:
+ *         description: List of students in the class
+ *       400:
+ *         description: classId is required
+ *       500:
+ *         description: Internal server error
+ */
 router.get('/classes/:classId/students', verifyToken, teacherController.getStudentListByClassController);
+
+
+/**
+ * @swagger
+ * /api/teacher/students/{studentId}/records:
+ *   get:
+ *     summary: Get learning records for a student
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: studentId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the student
+ *     responses:
+ *       200:
+ *         description: Student records fetched successfully
+ *       403:
+ *         description: Access denied
+ *       500:
+ *         description: Failed to fetch records
+ */
 router.get('/students/:studentId/records', verifyToken, teacherController.getRecordsByStudentIdController);
 
+
+/**
+ * @swagger
+ * /api/teacher/students/{studentId}/level:
+ *   post:
+ *     summary: Assign a level to a specific student
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: studentId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the student
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               assigned_level:
+ *                 type: string
+ *                 example: "A2"
+ *     responses:
+ *       200:
+ *         description: Assigned level updated successfully
+ *       400:
+ *         description: assigned_level is required
+ *       403:
+ *         description: Access denied
+ *       500:
+ *         description: Failed to update assigned level
+ */
 router.post('/students/:studentId/level', verifyToken, teacherController.setStudentAssignedLevelController);
+
+
+/**
+ * @swagger
+ * /api/teacher/classes/{classId}/level:
+ *   post:
+ *     summary: Assign a level to all students in a class
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: classId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the class
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               assigned_level:
+ *                 type: string
+ *                 example: "B1"
+ *     responses:
+ *       200:
+ *         description: All students in class updated to the assigned level
+ *       400:
+ *         description: assigned_level is required
+ *       403:
+ *         description: Access denied
+ *       500:
+ *         description: Failed to update levels
+ */
 router.post('/classes/:classId/level', verifyToken, teacherController.setClassAssignedLevelController);
 
+
+/**
+ * @swagger
+ * /api/teacher/classes/{classId}/keyword:
+ *   post:
+ *     summary: Set keyword for a class
+ *     tags: [Teacher]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: classId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the class
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               keyword:
+ *                 type: string
+ *                 example: "Space Exploration"
+ *     responses:
+ *       200:
+ *         description: Keyword updated successfully
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Class not found
+ *       500:
+ *         description: Failed to update keyword
+ */
 router.post('/classes/:classId/keyword', verifyToken, teacherController.setClassKeywordController);
 
 

--- a/backend/src/routes/text.routes.js
+++ b/backend/src/routes/text.routes.js
@@ -7,7 +7,7 @@ const { verifyToken } = require('../middleware/auth.middleware');
 
 /**
  * @swagger
- * /api/text/validate-keyword:
+ * /api/text/keywords/validate:
  *   post:
  *     summary: Validate if the given keyword is allowed (must not include any forbidden terms)
  *     tags: [Text]
@@ -54,7 +54,7 @@ const { verifyToken } = require('../middleware/auth.middleware');
  *                   type: string
  *                   example: '키워드 검증 중 오류가 발생했습니다.'
  */
-router.post('/validate-keyword', textController.validateKeyword);
+router.post('/keywords/validate', textController.validateKeyword);
 
 
 /**
@@ -313,15 +313,207 @@ router.post('/generate-text-low', textController.generateTextLow);
 router.get('/test', textController.testTextConnection);
 
 
+/**
+ * @swagger
+ * /api/text/feedback:
+ *   post:
+ *     summary: Save user feedback on a text
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               keyword:
+ *                 type: string
+ *               level:
+ *                 type: string
+ *               feedbacks:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Feedback saved successfully
+ *       500:
+ *         description: Failed to save feedback
+ */
 router.post('/feedback', verifyToken, textController.saveFeedbackController);
+
+
+/**
+ * @swagger
+ * /api/text/highlight:
+ *   post:
+ *     summary: Save highlighted text
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               text:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Highlight saved successfully
+ *       400:
+ *         description: Text is required
+ *       500:
+ *         description: Failed to save highlight
+ */
 router.post('/highlight', verifyToken,textController.saveHighlightController);
+
+
+/**
+ * @swagger
+ * /api/text/highlight:
+ *   delete:
+ *     summary: Delete a user's highlighted text
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               text:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Highlight deleted successfully
+ *       400:
+ *         description: Text is required
+ *       404:
+ *         description: Highlight not found
+ *       500:
+ *         description: Failed to delete highlight
+ */
 router.delete('/highlight', verifyToken,textController.deleteHighlightController);
-router.post('/check-answer', verifyToken, textController.checkAnswerController);
+
+
+/**
+ * @swagger
+ * /api/text/answers/verify:
+ *   post:
+ *     summary: Check user answer and return score and correctness
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               keyword:
+ *                 type: string
+ *               level:
+ *                 type: string
+ *               title:
+ *                 type: string
+ *               passage:
+ *                 type: string
+ *               question:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               answer:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               solution:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               userAnswer:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Answers checked successfully
+ *       500:
+ *         description: Failed to check answers
+ */
+router.post('/answers/verify', verifyToken, textController.checkAnswerController);
+
+
+/**
+ * @swagger
+ * /api/text/records:
+ *   get:
+ *     summary: Get records of the current user
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User records fetched successfully
+ *       500:
+ *         description: Failed to fetch records
+ */
 router.get('/records', verifyToken, textController.getUserRecordsController);
+
+
+/**
+ * @swagger
+ * /api/text/class-info:
+ *   get:
+ *     summary: Get class info for the current student
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Class info fetched successfully
+ *       400:
+ *         description: Student is not assigned to any class
+ *       403:
+ *         description: Only students can access class info
+ *       404:
+ *         description: Class not found
+ *       500:
+ *         description: Failed to fetch class info
+ */
 router.get('/class-info', verifyToken, textController.getClassInfoByStudentController);
 
+
 // [Attention] Static routes should be defined BEFORE dynamic ones!
-router.get('/:textId', verifyToken, textController.getTextByIdController);
+/**
+ * @swagger
+ * /api/text/contents/{textId}:
+ *   get:
+ *     summary: Get text by its ID
+ *     tags: [Text]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: textId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID of the text
+ *     responses:
+ *       200:
+ *         description: Text fetched successfully
+ *       500:
+ *         description: Failed to fetch text
+ */
+router.get('/contents/:textId', verifyToken, textController.getTextByIdController);
 
 
 module.exports = router;

--- a/backend/src/routes/text.routes.js
+++ b/backend/src/routes/text.routes.js
@@ -59,6 +59,121 @@ router.post('/keywords/validate', textController.validateKeyword);
 
 /**
  * @swagger
+ * /contents/{level}:
+ *   post:
+ *     summary: Generate text contents based on keyword and level
+ *     tags:
+ *       - Text Generation
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: level
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [low, medium, high]
+ *         description: User's learning level
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               keyword:
+ *                 type: string
+ *                 example: "Harry Potter"
+ *     responses:
+ *       200:
+ *         description: Successfully generated contents
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 keyword:
+ *                   type: string
+ *                   example: "Harry Potter"
+ *                 level:
+ *                   type: string
+ *                   example: "low"
+ *                 generation0:
+ *                   type: object
+ *                   properties:
+ *                     title:
+ *                       type: string
+ *                       example: "Who is Harry Potter?"
+ *                     passage:
+ *                       type: string
+ *                       example: "Harry Potter is a young wizard who discovers he has magical powers..."
+ *                     question:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example:
+ *                         - "What is Harry Potter?\nA normal boy\nA doctor\nA wizard\nA vampire\nA detective"
+ *                         - "Where does Harry go to learn magic?\nDurmstrang\nBeauxbatons\nHogwarts\nIlvermorny\nUagadou"
+ *                     answer:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example: ["c", "c", "c", "d", "d"]
+ *                     solution:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example:
+ *                         - "Harry is a wizard, not a normal boy or vampire."
+ *                         - "Harry studies magic at Hogwarts."
+ *                 generation1:
+ *                   type: object
+ *                   properties:
+ *                     title:
+ *                       type: string
+ *                     passage:
+ *                       type: string
+ *                     question:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     answer:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     solution:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                 generation2:
+ *                   type: object
+ *                   properties:
+ *                     title:
+ *                       type: string
+ *                     passage:
+ *                       type: string
+ *                     question:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     answer:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     solution:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *       401:
+ *         description: Unauthorized - missing or invalid token
+ *       500:
+ *         description: Internal Server Error
+ */
+router.post('/contents/:level', verifyToken, textController.generateContents);
+
+
+/**
+ * @swagger
  * /api/text/generate-text:
  *   post:
  *     summary: Generate text based on the provided keyword and user level (Authorization required)
@@ -166,7 +281,7 @@ router.post('/keywords/validate', textController.validateKeyword);
  *                   type: string
  *                   example: "텍스트 생성 중 오류가 발생했습니다."
  */
-router.post('/generate-text', verifyToken, textController.generateText);
+// router.post('/generate-text', verifyToken, textController.generateContents);
 
 
 /**
@@ -275,7 +390,7 @@ router.post('/generate-text', verifyToken, textController.generateText);
  *                   type: string
  *                   example: '텍스트 생성 중 오류가 발생했습니다.'
  */
-router.post('/generate-text-low', textController.generateTextLow);
+// router.post('/generate-text-low', textController.generateTextLow);
 
 
 /**

--- a/backend/src/services/text.service.js
+++ b/backend/src/services/text.service.js
@@ -37,7 +37,7 @@ const containsForbiddenKeyword = (text) => {
 };
 
 
-const requestGeneration = async (keyword, level, token) => {
+const requestGeneration = async (keyword, level, type, token) => {
   const forbiddenKeywords = loadForbiddenKeywordsFromJson();
 
   if (containsForbiddenKeyword(keyword, forbiddenKeywords)) {
@@ -49,18 +49,18 @@ const requestGeneration = async (keyword, level, token) => {
   try {
     console.log('Requesting generation for keyword:', keyword);
     console.log('Requesting generation for level:', level);
+    console.log('Requesting generation for type:', type);
 
     const generations = [];
 
     for (let i = 0; i < 3; i++) {
       const response = await axios.post(
-        `${process.env.CONTENTS_API}/generate/${level}`,
+        `${process.env.CONTENTS_API}/generate/${level}?type=${type}`,
         { keyword },
         {
           headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
+            Authorization: `Bearer ${token}`
+          }
         }
       );
       const generationData = response.data[`generation${i}`];

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,9 +11,9 @@ import '@fontsource/ibm-plex-sans-kr/700.css';
 import SplashPage from './pages/splash/Splash';
 import Login from './pages/login/Login';
 import StudentMain from './pages/student/main/StudentMain';
-import CustomLevelKeyword from './pages/student/mode-custom/Keyword';
-import CustomLevelResult from './pages/student/mode-custom/Result';
-import CustomLevelScore from './pages/student/mode-custom/Score';
+import KeywordInput from './pages/student/keyword-learning/KeywordInput';
+import KeywordSolve from './pages/student/keyword-learning/KeywordSolve';
+import KeywordScore from './pages/student/keyword-learning/KeywordScore';
 import StudentRecords from './pages/student/records/StudentRecords';
 
 import TeacherMain from './pages/teacher/main/TeacherMain';
@@ -28,9 +28,9 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/student" element={<StudentMain />} />
           <Route path="/student/records" element={<StudentRecords />} />
-          <Route path="/student/mode/custom" element={<CustomLevelKeyword />} />
-          <Route path="/student/mode/custom/result" element={<CustomLevelResult />} />
-          <Route path="/student/mode/custom/score" element={<CustomLevelScore />} />
+          <Route path="/student/mode/:mode" element={<KeywordInput />} />
+          <Route path="/student/mode/:mode/solve" element={<KeywordSolve />} />
+          <Route path="/student/mode/:mode/score" element={<KeywordScore />} />
 
           <Route path="/teacher" element={<TeacherMain />} />
           <Route path="/teacher/dashboard" element={<TeacherDashboardLayout />}>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -44,13 +44,13 @@ const CONFIG = {
   TEXT: {
     BASE_URL: `${BASE_URL}/text`,
     ENDPOINTS: {
-      VALIDATE_KEYWORD: '/validate-keyword',
+      VALIDATE_KEYWORD: '/keywords/validate',
       GENERATE_TEXT: '/generate-text',
       GENERATE_TEXT_LOW: '/generate-text-low',
       SAVE_FEEDBACK: '/feedback',
       SAVE_HIGHLIGHT: '/highlight',
       DELETE_HIGHLIGHT: '/highlight',
-      CHECK_ANSWER: '/check-answer',
+      CHECK_ANSWER: '/answers/verify',
       GET_RECORDS: '/records',
     },
   },

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -47,11 +47,13 @@ const CONFIG = {
       VALIDATE_KEYWORD: '/keywords/validate',
       GENERATE_TEXT: '/generate-text',
       GENERATE_TEXT_LOW: '/generate-text-low',
+      GENERATE_TEXT_CONTENTS: '/contents',
       SAVE_FEEDBACK: '/feedback',
       SAVE_HIGHLIGHT: '/highlight',
       DELETE_HIGHLIGHT: '/highlight',
       CHECK_ANSWER: '/answers/verify',
       GET_RECORDS: '/records',
+      CONTENTS_BY_ID: (textId) => `/contents/${textId}`,
     },
   },
 

--- a/frontend/src/pages/student/keyword-button/KeywordButtons.jsx
+++ b/frontend/src/pages/student/keyword-button/KeywordButtons.jsx
@@ -1,4 +1,4 @@
-// src/pages/student/keywords/KeywordButtons.jsx
+// src/pages/student/keyword-button/KeywordButtons.jsx
 
 import React from 'react';
 

--- a/frontend/src/pages/student/keyword-button/keyword-buttons.css
+++ b/frontend/src/pages/student/keyword-button/keyword-buttons.css
@@ -1,4 +1,4 @@
-/* src/pages/student/keywords/keyword-button.css */
+/* src/pages/student/keyword-button/keyword-buttons.css */
 
 @import '@/styles/theme.css';
 

--- a/frontend/src/pages/student/keyword-learning/KeywordScore.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordScore.jsx
@@ -1,12 +1,12 @@
-// src/pages/student/mode-custom/Score.jsx
+// src/pages/student/keyword-learning/KeywordScore.jsx
 
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import StudentHeader from '../header/StudentHeader';
-import './score.css';
+import './keyword-score.css';
 
-const CustomLevelScore = () => {
+const KeywordScore = () => {
   const location = useLocation();
   const [score, setScore] = useState(0);
   const [correctness, setCorrectness] = useState([]);
@@ -188,7 +188,7 @@ const CustomLevelScore = () => {
   );
 };
 
-export default CustomLevelScore;
+export default KeywordScore;
 
 const styles = {
   overlay: {

--- a/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
@@ -1,4 +1,4 @@
-// src/pages/student/mode-custom/Result.jsx
+// src/pages/student/keyword-learning/KeywordSolve.jsx
 
 import React, { useState, useEffect, useRef } from 'react';
 import FeedbackModal from '../feedback/FeedbackModal';
@@ -11,9 +11,9 @@ import CONFIG from '@/config';
 import StudentHeader from '../header/StudentHeader';
 import { HighlightToast, HighlightUndoToast } from '../toast/HighlightToast';
 
-import './result.css';
+import './keyword-solve.css';
 
-const CustomLevelResult = () => {
+const KeywordSolve = () => {
   const location = useLocation();
   const apiResponseData = location.state?.data;
 
@@ -203,7 +203,7 @@ const CustomLevelResult = () => {
       );
       console.log('Requested successfully:', response.data);
 
-      navigate('/student/mode/custom/score', {
+      navigate('/student/mode/${mode}/score', {
         state: {
           score: response.data.score,
           correctness: response.data.correctness,
@@ -315,4 +315,4 @@ const CustomLevelResult = () => {
   );
 };
 
-export default CustomLevelResult;
+export default KeywordSolve;

--- a/frontend/src/pages/student/keyword-learning/keyword-score.css
+++ b/frontend/src/pages/student/keyword-learning/keyword-score.css
@@ -1,4 +1,4 @@
-/* src/pages/student/mode-custom/score.css */
+/* src/pages/student/keyword-learning/keyword-score.css */
 
 .score-header h2 {
   font-size: 16px;

--- a/frontend/src/pages/student/keyword-learning/keyword-solve.css
+++ b/frontend/src/pages/student/keyword-learning/keyword-solve.css
@@ -1,4 +1,4 @@
-/* src/pages/student/mode-custom/result.css */
+/* src/pages/student/keyword-learning/keyword-solve.css */
 
 body {
   overflow: hidden;

--- a/frontend/src/pages/student/main/StudentMain.jsx
+++ b/frontend/src/pages/student/main/StudentMain.jsx
@@ -12,17 +12,17 @@ const StudentMain = () => {
   const modes = [
     {
       title: '맞춤형 난이도',
-      action: () => navigate('/student/mode/custom'),
+      action: () => navigate('/student/mode/personal'),
     },
 
     {
       title: '난이도 직접 설정',
-      action: () => navigate('/student/mode/select'),
+      action: () => navigate('/student/mode/manual'),
     },
 
     {
       title: '선생님 추천 난이도',
-      action: () => navigate('/student/mode/recommend'),
+      action: () => navigate('/student/mode/assigned'),
     },
   ];
 

--- a/frontend/src/pages/student/records/StudentRecords.jsx
+++ b/frontend/src/pages/student/records/StudentRecords.jsx
@@ -37,12 +37,7 @@ const StudentRecords = () => {
           uniqueTextIds.map(async (textId) => {
             try {
               const resText = await api.get(
-                `${CONFIG.TEXT.BASE_URL}/${textId}`,
-                {
-                  headers: {
-                    Authorization: `Bearer ${localStorage.getItem('token')}`,
-                  },
-                },
+                `${CONFIG.TEXT.BASE_URL}/contents/${textId}`
               );
               textsMapTemp[textId] = resText.data.data;
             } catch (err) {

--- a/frontend/src/pages/student/records/StudentRecords.jsx
+++ b/frontend/src/pages/student/records/StudentRecords.jsx
@@ -37,7 +37,7 @@ const StudentRecords = () => {
           uniqueTextIds.map(async (textId) => {
             try {
               const resText = await api.get(
-                `${CONFIG.TEXT.BASE_URL}/contents/${textId}`
+                `${CONFIG.TEXT.BASE_URL}${CONFIG.TEXT.ENDPOINTS.CONTENTS_BY_ID(textId)}`
               );
               textsMapTemp[textId] = resText.data.data;
             } catch (err) {

--- a/frontend/src/pages/teacher/header/TeacherHeader.jsx
+++ b/frontend/src/pages/teacher/header/TeacherHeader.jsx
@@ -1,0 +1,42 @@
+// src/pages/teacher/header/TeacherHeader.jsx
+
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { persistor } from '@/store';
+import { useNavigate } from 'react-router-dom';
+import { logout } from '@/store/authSlice';
+
+import './teacher-header.css';
+
+const TeacherHeader = () => {
+  const { isLoggedIn, userInfo } = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleMenuClick = () => {
+    // navigate('/teacher/temp-route');
+  };
+
+  const handleLogoutClick = () => {
+    dispatch(logout()); // initialize Redux state
+    persistor.purge(); // initialize redux-persist state
+    navigate('/'); // redirect to '/'
+  };
+
+  return (
+    <header className="teacher-header">
+      <div className="teacher-header-info">
+        {isLoggedIn
+          ? `${userInfo.school || '학교명'} | ${userInfo.name || '이름'}`
+          : '2xAI'}
+      </div>
+
+      <div className="teacher-header-buttons">
+        <button onClick={handleMenuClick}>tempBtn</button>
+        <button onClick={handleLogoutClick}>로그아웃</button>
+      </div>
+    </header>
+  );
+};
+
+export default TeacherHeader;

--- a/frontend/src/pages/teacher/header/teacher-header.css
+++ b/frontend/src/pages/teacher/header/teacher-header.css
@@ -1,0 +1,52 @@
+/* src/pages/teacher/header/teacher-header.css */
+
+@import '@/styles/theme.css';
+
+.teacher-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 12vh;
+  padding: 0 20px;
+  background-color: #f4f4f4;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10;
+  box-sizing: border-box;
+}
+
+.teacher-header-info {
+  font-family: 'IBM Plex Sans KR', sans-serif;
+  font-size: 45px;
+  font-weight: bold;
+  color: black;
+  flex-grow: 0;
+  flex-shrink: 0;
+  margin-left: 10px;
+}
+
+.teacher-header-buttons {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-grow: 0;
+  margin-right: 10px;
+}
+
+.teacher-header-buttons button {
+  padding: 8px 20px;
+  background-color: var(--gray-button-color);
+  color: white;
+  border: none;
+  cursor: pointer;
+  border-radius: 20px;
+  font-family: 'IBM Plex Sans KR', sans-serif;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.teacher-header-buttons button:hover {
+  background-color: var(--gray-button-hover-color);
+}

--- a/frontend/src/pages/teacher/main/TeacherMain.jsx
+++ b/frontend/src/pages/teacher/main/TeacherMain.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-// import TeacherHeader from '../header/TeacherHeader';
+import TeacherHeader from '../header/TeacherHeader';
 import './teacher-main.css';
 
 const TeacherMain = () => {
@@ -28,7 +28,7 @@ const TeacherMain = () => {
 
   return (
     <div className="teacher-main-container">
-      {/* <TeacherHeader /> */}
+      <TeacherHeader />
 
       <h2 className="main-header-text">항목을 선택해 주세요</h2>
 

--- a/frontend/src/store/authSlice.js
+++ b/frontend/src/store/authSlice.js
@@ -71,15 +71,30 @@ const authSlice = createSlice({
         state.status = 'loading';
       })
       .addCase(login.fulfilled, (state, action) => {
-        state.token = action.payload.token;
-        state.redirect = action.payload.redirect;
+        const { token, redirect, role, name, classInfo, studentLevels, school } = action.payload;
+
+        state.token = token;
+        state.redirect = redirect;
         state.isLoggedIn = true;
-        state.userInfo = {
-          school: action.payload.classInfo?.schoolName || '',
-          name: action.payload.name || '',
-          inferredLevel: action.payload.studentLevels?.inferredLevel || 'low',
-          assignedLevel: action.payload.studentLevels?.assignedLevel || 'low',
+
+        let userInfo = {
+          name: name || '',
+          school: '',
+          inferredLevel: 'low',
+          assignedLevel: 'low',
         };
+
+        if (role === 'student') {
+          userInfo.school = classInfo?.schoolName || '';
+          userInfo.inferredLevel = studentLevels?.inferredLevel || 'low';
+          userInfo.assignedLevel = studentLevels?.assignedLevel || 'low';
+        } else if (role === 'teacher') {
+          userInfo.school = classInfo?.schoolName || '';
+        } else if (role === 'admin') {
+          userInfo.school = '2xAI';
+        }
+
+        state.userInfo = userInfo;
         state.status = 'succeeded';
 
         localStorage.setItem('token', action.payload.token);


### PR DESCRIPTION
## 🔗 Issue
- refs #7
- refs #8
- refs #23
- refs #35
- refs #38

## 📌 Summary

- 🧩 **[FE]** **`TeacherHeader`** 추가
  - 교사 사용자 정보 표시하기 위해 (BE) **login API**, (FE) **authSlice** 수정

- 🧩 **[FE]** 학생 사용자의 **학습 모드**에 따른 페이지들을 **공통 component**로 모듈화

---

✅ **[FE]** student learning **mode identifiers** (routes) vs. **level type**
| mode identifier | route    |
|------------------|----------|
| `/personal`        | `inferred` |
| `/manual`          | `selected` |
| `/assigned`        | `assigned` |

- 🔧 **[BE]** level type과 level에 따라 동적으로 text contents 생성 요청하도록 **API 수정**
  - **`POST /api/text/contents/{level}?type=inferred`**
  - **`POST /api/text/contents/{level}?type=selected`**
  - **`POST /api/text/contents/{level}?type=assigned`**

- 🧪 **[test]** Node.js API와 연동되도록 **`FastAPI` test server** 수정 (dynamic endpoint)

---

- 🔧 [BE] **REST API의 설계 원칙**에 따라 일부 API endpoint 수정

  - 🔧 [FE] update config.js: `GENERATE_TEXT_CONTENTS`, `CONTENTS_BY_ID`