### PR TITLE
🔧 QA 테스트 수정사항 반영 v12

### DIFF
--- a/backend/src/models/generation.js
+++ b/backend/src/models/generation.js
@@ -1,0 +1,42 @@
+// models/generation.js
+
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const generationSchema = new mongoose.Schema({
+  keyword: { type: String, required: true },
+  level: {
+    type: String,
+    required: true,
+    enum: ['low', 'middle', 'high'],
+  },
+  generation0: {
+    title: String,
+    passage: String,
+    question: [String],
+    answer: [String],
+    solution: [String],
+  },
+  generation1: {
+    title: String,
+    passage: String,
+    question: [String],
+    answer: [String],
+    solution: [String],
+  },
+  generation2: {
+    title: String,
+    passage: String,
+    question: [String],
+    answer: [String],
+    solution: [String],
+  },
+  usedBy: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+}, {
+  timestamps: { createdAt: true, updatedAt: false },
+  versionKey: false,
+});
+
+const Generation = mongoose.model('Generation', generationSchema, 'generations');
+
+module.exports = Generation;


### PR DESCRIPTION
## 🔗 Issue

- relates to #77

## 📌 Summary

- ✨ **[DB]** **`GenerationSchema`** 추가

  - 사전 생성된 지문 세트를 저장할 schema -- `keyword`, `level`

  - 🔗 closes #78

---

- ✨ **[BE]** 기존의 지문 생성 요청 **API 수정** -- service, controller

  - `generations` collection에서 `keyword`, `level` 조합의 지문 검색

  - 학생 사용자가 동일 지문을 풀이하지 않도록 사용자 정보 저장

  - DB의 `generations` collection에 풀이할 지문 세트가 없는 경우 AI 서버에 새로운 지문 생성 요청

  - 🔗 refs #79