### PR TITLE
🔧 QA 테스트 수정사항 반영 v14

### DIFF
--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -51,11 +51,17 @@ exports.generateContentsController = async (req, res) => {
       return res.status(400).json({ message: 'ERROR: invalid type' });
     }
 
+    // 사용자 정보 갱신
+    const user = await User.findById(userId).select('student_info');
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
     let userLevel;
     if (type === 'inferred') {
-      userLevel = userInfo.inferredLevel;
+      userLevel = user.student_info?.inferred_level;
     } else if (type === 'assigned') {
-      userLevel = userInfo.assignedLevel;
+      userLevel = user.student_info?.assigned_level;
     } else if (type === 'selected') {
       userLevel = level;
     }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# font
+/public/fonts/NanumGothicEncoded.txt

--- a/frontend/src/pages/student/records/StudentRecords.jsx
+++ b/frontend/src/pages/student/records/StudentRecords.jsx
@@ -131,7 +131,7 @@ const StudentRecords = () => {
           text={selectedRecord.text}
           record={selectedRecord.record}
           onClose={() => setSelectedRecord(null)}
-          onDownload={(type) => handleDownload(selectedRecord.text, type)}
+          onDownload={(type) => handleDownload(type, selectedRecord.text, selectedRecord.record)}
         />
       )}
     </div>


### PR DESCRIPTION
## 🔗 Issue

- relates to #83

## 📌 Summary

- 🐛 **[BE]** 지문 생성 요청 전, DB에 저장된 사용자의 **난이도 정보**를 **동기화**하는 로직 추가

  - 🔗 closes #84

---

- 🐛 **[FE]** 학습 자료 PDF 파일 다운로드 시 **한글** 텍스트가 깨지는 문제 수정

  - 한글 지원하는 `NanumGothic` font의 **`ttf`** 파일 추가

  - `jsPDF`에서 사용할 수 있도록 **`base64`** encoding

  - 해당 font를 **load하여** PDF 파일로 다운로드할 수 있도록 함수 수정

  - 🔗 closes #85

---

- 🐛 **[FE]** 학습 자료 파일 다운로드 시 `학생 답안`과 `정답` 함께 표시하도록 수정

  - 학습 결과(`record`)에 저장된 '학생 답안'을 추가로 표시할 수 있도록 `props` 수정

  - 🔗 closes #86

---

#### 🧪 local test completed