### PR TITLE
🔧 QA 테스트 수정사항 반영 v19

### DIFF
--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -241,7 +241,7 @@ exports.uploadHighlightImageController = async (req, res) => {
 exports.checkAnswerController = async (req, res) => {
 
   const { userId } = req.user;
-  const { keyword, level, title, passage, question, answer, solution, userAnswer, elapsedSeconds, } = req.body;
+  const { keyword, level, title, passage, question, answer, solution, userAnswer, elapsedSeconds, mode, } = req.body;
   
   
   try {
@@ -270,6 +270,7 @@ exports.checkAnswerController = async (req, res) => {
       correctAnswer: answer,
       score,
       elapsedSeconds,
+      mode,
     });
     await newRecord.save();
 

--- a/backend/src/models/record.js
+++ b/backend/src/models/record.js
@@ -11,6 +11,7 @@ const recordSchema = new Schema({
   correctAnswer: { type: [String], required: true },
   score: { type: Number, required: true },
   elapsedSeconds: { type: Number },
+  mode: { type: String, enum: ['inferred', 'selected', 'assigned'], required: true },
 }, {
   timestamps: { createdAt: true, updatedAt: false },
   versionKey: false,

--- a/frontend/src/pages/student/keyword-learning/KeywordInput.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordInput.jsx
@@ -138,7 +138,7 @@ const KeywordInput = () => {
       setIsLoading(false);
 
       navigate(`/student/mode/${mode}/solve`, {
-        state: { data: response.data },
+        state: { data: response.data, mode },
       });
     } catch (error) {
       console.error('Error generating text:', error);

--- a/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
@@ -22,6 +22,15 @@ import './keyword-solve.css';
 const KeywordSolve = () => {
   const location = useLocation();
   const apiResponseData = location.state?.data;
+  const mode = location.state?.mode;
+
+  const modeToRecordMode = {
+    personal: 'inferred',
+    manual: 'selected',
+    assigned: 'assigned',
+  };
+
+  const recordMode = modeToRecordMode[mode];
 
   const generations = [
     apiResponseData.generation0,
@@ -294,6 +303,7 @@ const KeywordSolve = () => {
           solution: selectedGeneration.solution,
           userAnswer: answers,
           elapsedSeconds,
+          mode: recordMode,
         },
       );
       console.log('Requested successfully:', response.data);

--- a/frontend/src/pages/student/records/StudentRecords.jsx
+++ b/frontend/src/pages/student/records/StudentRecords.jsx
@@ -23,6 +23,18 @@ const StudentRecords = () => {
     high: '상',
   };
 
+  const modeMap = {
+    inferred: (
+      <>맞춤형<br />난이도</>
+    ),
+    selected: (
+      <>직접<br />선택</>
+    ),
+    assigned: (
+      <>교사<br />추천</>
+    ),
+  };
+
   useEffect(() => {
     const fetchRecords = async () => {
       try {
@@ -81,6 +93,7 @@ const StudentRecords = () => {
               <th>No.</th>
               <th>키워드</th>
               <th>난이도</th>
+              <th>유형</th>
               <th>지문 제목</th>
               <th>지문</th>
               <th>시간</th>
@@ -90,7 +103,7 @@ const StudentRecords = () => {
           <tbody>
             {records.map((record, idx) => {
               const text = textsMap[record.textId];
-              const shortPassage = (text?.passage || '').replace(/\n/g, ' ').slice(0, 200) || '-';
+              const shortPassage = (text?.passage || '').replace(/\n/g, ' ').slice(0, 190) || '-';
 
               return (
                 <tr
@@ -103,6 +116,7 @@ const StudentRecords = () => {
                   <td>{idx + 1}</td>
                   <td>{text?.keyword || '-'}</td>
                   <td>{levelMap[text?.level] || '-'}</td>
+                  <td>{modeMap[record.mode] || '-'}</td>
                   <td>{text?.title || '-'}</td>
                   <td>{shortPassage || '-'}</td>
                   <td>

--- a/frontend/src/pages/student/records/student-records.css
+++ b/frontend/src/pages/student/records/student-records.css
@@ -88,12 +88,13 @@ td {
 
 /* table column width */
 .records-container th:nth-child(1), .records-container td:nth-child(1) { width: 0.5vw; }  /* No. */
-.records-container th:nth-child(2), .records-container td:nth-child(2) { width: 4.0vw; }  /* 키워드 */
+.records-container th:nth-child(2), .records-container td:nth-child(2) { width: 3.5vw; }  /* 키워드 */
 .records-container th:nth-child(3), .records-container td:nth-child(3) { width: 1.3vw; }  /* 난이도 */
-.records-container th:nth-child(4), .records-container td:nth-child(4) { width: 5.0vw; }  /* 제목 */
-.records-container th:nth-child(5), .records-container td:nth-child(5) { width: 10.0vw; } /* 지문 */
-.records-container th:nth-child(6), .records-container td:nth-child(6) { width: 2.5vw; }  /* 풀이 시간 */
-.records-container th:nth-child(7), .records-container td:nth-child(7) { width: 2.5vw; }  /* 풀이 결과 */
+.records-container th:nth-child(4), .records-container td:nth-child(4) { width: 1.5vw; }  /* 학습 모드 */
+.records-container th:nth-child(5), .records-container td:nth-child(5) { width: 5.0vw; }  /* 제목 */
+.records-container th:nth-child(6), .records-container td:nth-child(6) { width: 10.0vw; } /* 지문 */
+.records-container th:nth-child(7), .records-container td:nth-child(7) { width: 2.5vw; }  /* 풀이 시간 */
+.records-container th:nth-child(8), .records-container td:nth-child(8) { width: 2.5vw; }  /* 풀이 결과 */
 
 .answer-correct {
   color: green;

--- a/frontend/src/pages/teacher/results/ResultsDetail.jsx
+++ b/frontend/src/pages/teacher/results/ResultsDetail.jsx
@@ -39,6 +39,18 @@ const ResultsDetail = () => {
     high: '상',
   };
 
+  const modeMap = {
+    inferred: (
+      <>맞춤형<br />난이도</>
+    ),
+    selected: (
+      <>직접<br />선택</>
+    ),
+    assigned: (
+      <>교사<br />추천</>
+    ),
+  };
+
   useEffect(() => {
     const fetchRecords = async () => {
       try {
@@ -97,6 +109,7 @@ const ResultsDetail = () => {
               <th>No.</th>
               <th>키워드</th>
               <th>난이도</th>
+              <th>유형</th>
               <th>지문 제목</th>
               <th>지문</th>
               <th>제출 시간</th>
@@ -108,7 +121,7 @@ const ResultsDetail = () => {
             {records.map((record, idx) => {
               const text = textsMap[record.textId];
               const shortPassage =
-                (text?.passage || '').replace(/\n/g, ' ').slice(0, 200) || '-';
+                (text?.passage || '').replace(/\n/g, ' ').slice(0, 170) || '-';
 
               return (
                 <tr
@@ -119,6 +132,7 @@ const ResultsDetail = () => {
                   <td>{idx + 1}</td>
                   <td>{text?.keyword || '-'}</td>
                   <td>{levelMap[text?.level] || '-'}</td>
+                  <td>{modeMap[record.mode] || '-'}</td>
                   <td>{text?.title || '-'}</td>
                   <td>{shortPassage}</td>
                   <td>

--- a/frontend/src/pages/teacher/results/results-detail.css
+++ b/frontend/src/pages/teacher/results/results-detail.css
@@ -78,13 +78,14 @@
 
 /* column width */
 .results-detail-container th:nth-child(1), .results-detail-container td:nth-child(1) { width: 0.5vw; }  /* No. */
-.results-detail-container th:nth-child(2), .results-detail-container td:nth-child(2) { width: 4vw; }    /* 키워드 */
-.results-detail-container th:nth-child(3), .results-detail-container td:nth-child(3) { width: 1.5vw; }  /* 난이도 */
-.results-detail-container th:nth-child(4), .results-detail-container td:nth-child(4) { width: 5vw; }    /* 제목 */
-.results-detail-container th:nth-child(5), .results-detail-container td:nth-child(5) { width: 13vw; }   /* 지문 */
-.results-detail-container th:nth-child(6), .results-detail-container td:nth-child(6) { width: 2.8vw; }  /* 제출 시간 */
-.results-detail-container th:nth-child(7), .results-detail-container td:nth-child(7) { width: 2.5vw; }  /* 제출 시간 */
-.results-detail-container th:nth-child(8), .results-detail-container td:nth-child(8) { width: 2.5vw; }  /* 풀이 결과 */
+.results-detail-container th:nth-child(2), .results-detail-container td:nth-child(2) { width: 3.5vw; }  /* 키워드 */
+.results-detail-container th:nth-child(3), .results-detail-container td:nth-child(3) { width: 1.6vw; }  /* 난이도 */
+.results-detail-container th:nth-child(4), .results-detail-container td:nth-child(4) { width: 1.7vw; }  /* 학습 모드 */
+.results-detail-container th:nth-child(5), .results-detail-container td:nth-child(5) { width: 5.0vw; }  /* 제목 */
+.results-detail-container th:nth-child(6), .results-detail-container td:nth-child(6) { width: 10.0vw; } /* 지문 */
+.results-detail-container th:nth-child(7), .results-detail-container td:nth-child(7) { width: 2.8vw; }  /* 제출 시간 */
+.results-detail-container th:nth-child(8), .results-detail-container td:nth-child(8) { width: 2.2vw; }  /* 소요 시간 */
+.results-detail-container th:nth-child(9), .results-detail-container td:nth-child(9) { width: 2.5vw; }  /* 풀이 결과 */
 
 .results-detail-container td {
   white-space: pre-wrap;


### PR DESCRIPTION
## 🔗 Issue

- closes #98

- closes #93

## 📌 Summary

- ✨ **[DB]** `Records` schema에 학습 모드 저장을 위한 필드 추가

- ✨ **[BE]** 답안 제출 시 학습 모드 데이터를 저장하도록 **API** 수정

- 🔗 closes #99

---

- ✨ **[FE]** 학습 모드 정보 저장을 위한 **props** 및 **frontend** 코드 수정

  - 학습 자료 생성 요청이 이루어지는 페이지에서 **props**로 '**mode**' 데이터 넘기기

  - 답안 제출 시 학습 모드 데이터도 **API payload**에 포함되도록 수정

  - 🔗 closes #100

---

- ✨ **[FE]** 학습 결과 화면에 '학습 모드' 데이터 추가로 표시

  - 학생 결과 화면에 추가

  - `ResultsDetail` -- (교사/관리자 공통) 학습 결과 확인 화면에 추가

  - 🔗 closes #101

---

#### 🧪 local test completed