### PR TITLE
🔧 QA 테스트 수정사항 반영 v23

### DIFF
--- a/backend/src/models/errorLog.js
+++ b/backend/src/models/errorLog.js
@@ -1,0 +1,25 @@
+// models/errorLog.js
+
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const errorLogSchema = new mongoose.Schema({
+  keyword: { type: String },
+  level: { type: String, enum: ['high', 'middle', 'low'] },
+  type: { type: String, enum: ['inferred', 'assigned', 'selected'] },
+  errorType: { type: String },
+  errorMessage: { type: String },
+  stackTrace: { type: String },
+
+  username: { type: String },
+  schoolName: { type: String },
+  className: { type: String },
+  name: { type: String },
+  userId: { type: Schema.Types.ObjectId, ref: 'User' },
+
+  timestamp: { type: Date, default: Date.now },
+}, {
+  versionKey: false
+});
+
+module.exports = mongoose.model('ErrorLog', errorLogSchema, 'errorlogs');


### PR DESCRIPTION
## 🔗 Issue

- relates to #109

## 📌 Summary

- 🐛 **[BE]** AI 서버에서 학습 자료 생성 시 발생하는 **`ValidationError` 오류 추적** 위해 로그 저장

  - [DB] `ErrorLog` schema 추가 -- 해당 사용자 정보, timestamp (UTC) 등 저장

  - [BE] **`ValidationError`** 에 대한 **오류 처리(422)** 및 **로그 저장** 추가 -- `text.controller.js`

  - 🔗 closes #110

---

#### 🧪 local test completed