### PR TITLE
🔧 QA 테스트 수정사항 반영 v24

### DIFF
--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -82,7 +82,18 @@ exports.generateContentsController = async (req, res) => {
       return res.status(401).json({ message: 'Unauthorized: user ID missing in token' });
     }
 
-    const result = await textService.requestGeneration(keyword, level, userId, type, token);
+    // const result = await textService.requestGeneration(keyword, level, userId, type, token);
+    const result = await textService.requestGeneration(
+      keyword,
+      level,
+      userId,
+      type,
+      token,
+      {
+        username: user.username || '',
+        name: user.name || '',
+      }
+    );
 
     const hasValidationError =
       result.generation0?.title === 'ValidationError' ||

--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -5,6 +5,7 @@ const User = require('../models/user')
 const Class = require('../models/class')
 const Text = require('../models/text');
 const Record = require('../models/record');
+const Keyword = require('../models/keyword');
 const ErrorLog = require('../models/errorLog');
 
 // POST /api/text/keywords/validate
@@ -80,6 +81,22 @@ exports.generateContentsController = async (req, res) => {
 
     if (!userId) {
       return res.status(401).json({ message: 'Unauthorized: user ID missing in token' });
+    }
+
+    // keyword tracking
+    try {
+      await Keyword.create({
+        keyword,
+        level,
+        type,
+        username: user.username || '',
+        name: user.name || '',
+        schoolName: user.class_id?.school_name || '',
+        className: user.class_id?.class_name || '',
+        userId: user._id,
+      });
+    } catch(error) {
+      console.error('Failed to save keyword log:', err);
     }
 
     // const result = await textService.requestGeneration(keyword, level, userId, type, token);

--- a/backend/src/models/keyword.js
+++ b/backend/src/models/keyword.js
@@ -1,0 +1,22 @@
+// models/keyword.js
+
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const keywordSchema = new mongoose.Schema({
+  keyword: { type: String, required: true },
+  level: { type: String, enum: ['high', 'middle', 'low'], required: true },
+  type: { type: String, enum: ['inferred', 'assigned', 'selected'], required: true },
+
+  username: { type: String },
+  name: { type: String },
+  schoolName: { type: String },
+  className: { type: String },
+  userId: { type: Schema.Types.ObjectId, ref: 'User' },
+
+  createdAt: { type: Date, default: Date.now },
+}, {
+  versionKey: false,
+});
+
+module.exports = mongoose.model('Keyword', keywordSchema, 'keywords');

--- a/backend/src/services/text.service.js
+++ b/backend/src/services/text.service.js
@@ -60,19 +60,25 @@ const containsForbiddenKeyword = (text) => {
 };
 
 
-const requestGeneration = async (keyword, level, userId, type, token) => {
+const requestGeneration = async (keyword, level, userId, type, token, userInfo = {}) => {
+  const { username = 'unknown', name = 'unknown' } = userInfo;
+
+  const timestamp = new Date(Date.now() + 9 * 60 * 60 * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .slice(0, 19);
   const forbiddenKeywords = loadForbiddenKeywordsFromJson();
 
   if (containsForbiddenKeyword(keyword, forbiddenKeywords)) {
+    console.warn(`[금지어 입력] ${username} ${name} - keyword "${keyword}" - ${timestamp} KST`);
+
     const error = new Error('금지어가 포함되어 있습니다.');
     error.status = 400;
     throw error;
   }
 
   try {
-    console.log('Requesting generation for keyword:', keyword);
-    console.log('Requesting generation for level:', level);
-    console.log('Requesting generation for type:', type);
+    console.log(`[request] ${username} ${name} - keyword: ${keyword} (${level} / ${type}) - ${timestamp} KST`);
 
     const response = await axios.post(
       `${process.env.CONTENTS_API}/generate/${level}?type=${type}`,


### PR DESCRIPTION
## 🔗 Issue

- closes #109

## 📌 Summary

- ✨ **[BE]** 학습 자료 생성 요청 및 금지어 입력에 대한 **상세 로그 추가**

  - **요청한 키워드**는 로그에서 확인 가능하지만, **현장 실험 모니터링** 과정에서 **어떤 학생**이 요청했는지 확인하기 어려웠음

    - timestamp(UTC)를 포함한 **세부 정보**를 Node.js 서버 로그에서 바로 확인할 수 있도록 **로그 개선**

    - 금지어 입력 시 바로 **오류 처리**되었지만, **어떤 금지어**를 입력했는지 확인할 수 있도록 **로그 개선**

  - `keywordSchema` 추가하여 **학생이 입력한 키워드**를 사용자 정보, timestamp(UTC) 등과 함께 저장

  - 🔗 closes #112

---

#### 🧪 local test completed