### PR TITLE
🔧 QA 테스트 수정사항 반영 v28

### DIFF
--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -26,7 +26,7 @@ const verifyToken = (req, res, next) => {
     next();
   } catch (error) {
     // token is INVALID or EXPIRED
-    return res.status(401).json({ message: 'Invalid token' });
+    return res.status(401).json({ message: '세션이 만료되었습니다. 로그아웃 후 다시 로그인해 주세요.' });
   }
 };
 

--- a/frontend/src/pages/student/feedback/FeedbackModal.jsx
+++ b/frontend/src/pages/student/feedback/FeedbackModal.jsx
@@ -1,6 +1,7 @@
 // src/pages/student/feedback/FeedbackModal.jsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Modal from 'react-modal';
 
 import { api } from '@/config';
@@ -30,9 +31,11 @@ const FeedbackModal = ({
   setFinalChoiceIndex,
   onConfirmSelection,
   generations,
-  keyword = { keyword },
-  level = { level },
+  keyword,
+  level,
+  mode,
 }) => {
+  const navigate = useNavigate();
   const totalPages = generations.length + 1;
 
   const currentGeneration =
@@ -114,6 +117,17 @@ const FeedbackModal = ({
             </div>
 
             <div className="feedback-modal-right">
+              <button
+                className="retry-btn"
+                onClick={() => {
+                  onClose();
+                  const targetMode = mode || 'personal';
+                  navigate(`/student/mode/${targetMode}`, { replace: true });
+                }}
+              >
+                ↩️ 다시 시도
+              </button>
+
               <h4>읽기 자료가 마음에 드나요?</h4>
               <button
                 className={`feedback-btn ${feedbacks[currentPage]?.choice === 'good' ? 'selected' : ''}`}

--- a/frontend/src/pages/student/feedback/feedback-modal.css
+++ b/frontend/src/pages/student/feedback/feedback-modal.css
@@ -133,7 +133,7 @@
   white-space: nowrap;
   cursor: pointer;
   border: none;
-  font-size: 1rem;
+  font-size: 16px;
   align-items: center;
   width: 90%;
   background-color: var(--blue-color-4);
@@ -174,9 +174,14 @@
   margin-top: 0px;
 }
 
+.user-feedback {
+  font-size: 15px;
+}
+
 .confirm-btn {
   margin-top: 0px;
-  width: 15vw;
+  width: 200px;
+  height: 60px;
   border: none;
 }
 
@@ -211,6 +216,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 15px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/pages/student/feedback/feedback-modal.css
+++ b/frontend/src/pages/student/feedback/feedback-modal.css
@@ -74,6 +74,7 @@
 .feedback-modal-right h4 {
   font-size: 24px;
   text-align: center;
+  margin-top: 0.5vh;
   margin-bottom: 1.5vh;
 }
 
@@ -87,7 +88,7 @@
   font-size: 20px;
   cursor: pointer;
   border: none;
-  width: 22vw;
+  width: 300px;
   background-color: var(--blue-color-5);
   height: 60px;
 }
@@ -219,13 +220,27 @@
   font-size: 15px;
 }
 
+.retry-btn {
+  margin-top: 10px;
+  margin-bottom: 0px;
+  margin-left: auto;
+  margin-right: 40px;
+  background-color: var(--blue-color-4);
+  width: 150px;
+  height: 45px;
+  font-size: 17px;
+  align-items: right;
+  border: none;
+  cursor: pointer;
+}
+
 @media (prefers-color-scheme: dark) {
 
   .feedback-modal {
     background-color: var(--bg-color);
   }
 
-  .feedback-btn, .final-select-button, .confirm-btn {
+  .feedback-btn, .final-select-button, .confirm-btn, .retry-btn {
     background-color: var(--dark-mode-main-color);
     color: var(--bg-color);
     font-weight: bold;

--- a/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import FeedbackModal from '../feedback/FeedbackModal';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import html2canvas from 'html2canvas';
 import { CircularProgress } from '@mui/material'
@@ -21,8 +21,12 @@ import './keyword-solve.css';
 
 const KeywordSolve = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const params = useParams();
+
   const apiResponseData = location.state?.data;
-  const mode = location.state?.mode;
+  const mode = location.state?.mode || params.mode || 'personal';
 
   const modeToRecordMode = {
     personal: 'inferred',
@@ -68,6 +72,13 @@ const KeywordSolve = () => {
       navigator.msMaxTouchPoints > 0
     );
   };
+
+  useEffect(() => {
+    if (!location.state || !location.state.data) {
+      alert('페이지를 새로고침하여 정보가 초기화되었습니다. 키워드 입력 화면으로 이동합니다.');
+      navigate(`/student/mode/${mode}`, { replace: true });
+    }
+  }, [location.state, navigate, mode]);
 
   useEffect(() => {
     if (!passageRef.current) return;
@@ -369,9 +380,6 @@ const KeywordSolve = () => {
     }
   };
 
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-
   const submitAnswers = async () => {
     setIsSubmitting(true);
 
@@ -454,6 +462,7 @@ const KeywordSolve = () => {
         generations={generations} // actual data (API response)
         keyword={keyword}
         level={level}
+        mode={mode}
       />
 
       {showLabelDropdown && (


### PR DESCRIPTION
## 🔗 Issue

- relates to #122

## 📌 Summary

- 🐛 **[FE]** 문제 풀이 **버튼 비활성화** 오류 수정

  - 관련 component의 일부 CSS 요소를 절댓값으로 고정

  - 🔗 closes #123

---

- 🔧 **[BE]** **access token이 만료**된 경우(**401 오류**)의 메시지 수정

  - 현장 실험에서 `Invalid token`이 화면에 표시된 경우, 학생 사용자들에게 **다시 로그인**하도록 안내하였음

  - 화면에 **안내 메시지**를 표시할 수 있도록 오류 처리 코드 수정

  - 🔗 closes #125

---

- 🐛 **[FE]** 문제 풀이 과정에서 `새로고침` 또는 `뒤로가기` 버튼 클릭 시의 **상태 관리** 문제 개선

  - 상태가 비정상적으로 초기화되거나, 학습 풀이 결과가 중복 저장되는 등의 이슈가 종종 발생함

  - `KeywordSovle` page component에서 **상태 관리**에 대한 **defensive code** 추가 (**state validation**)

  - `FeedbackModal`에서 문제 발생 시 refresh/back 대신 사용할 수 있도록 **버튼 추가** → **키워드 입력 화면**으로 이동

  - 🔗 closes #124

---

#### 🧪 local test completed