### PR TITLE
🔧 QA 테스트 수정사항 반영 v29

### DIFF
--- a/backend/src/controllers/text.controller.js
+++ b/backend/src/controllers/text.controller.js
@@ -207,14 +207,15 @@ exports.testTextConnection = async (req, res) => {
 // POST /api/text/feedback
 exports.saveFeedbackController = async (req, res) => {
   try {
-
     const { userId } = req.user;
     const { keyword, level, feedbacks } = req.body;
 
-    // generate feedback data
-    const feedbackData = textService.generateFeedbackData(keyword, level, feedbacks);
-
-    feedbackData.userId = userId;
+    const feedbackData = {
+      userId,
+      keyword,
+      level,
+      feedbacks,
+    };
 
     const result = await textService.saveFeedback(feedbackData);
 
@@ -304,7 +305,8 @@ exports.uploadHighlightImageController = async (req, res) => {
 exports.checkAnswerController = async (req, res) => {
 
   const { userId } = req.user;
-  const { keyword, level, title, passage, question, answer, solution, userAnswer, elapsedSeconds, mode, } = req.body;
+  const { keyword, level, title, passage, question, answer, solution, userAnswer, elapsedSeconds, mode, feedbackId } = req.body;
+
 
   try {
     const { userAnswer: userAnswerStrArray, correctness } = textService.checkAnswer(userAnswer, answer);
@@ -333,6 +335,7 @@ exports.checkAnswerController = async (req, res) => {
       score,
       elapsedSeconds,
       mode,
+      feedbackId,
     });
     await newRecord.save();
 

--- a/backend/src/models/record.js
+++ b/backend/src/models/record.js
@@ -6,6 +6,8 @@ const { Schema } = mongoose;
 const recordSchema = new Schema({
   userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   textId: { type: Schema.Types.ObjectId, ref: 'Text', required: true },
+  feedbackId: { type: Schema.Types.ObjectId, ref: 'Feedback' },
+
   correctness: { type: [Boolean], required: true },
   userAnswer: { type: [String], required: true },
   correctAnswer: { type: [String], required: true },

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -360,4 +360,77 @@ router.get('/classes', verifyToken, adminController.getAllClassesController);
 router.get('/feedbacks', verifyToken, adminController.getFeedbacksController);
 
 
+/**
+ * @swagger
+ * /api/admin/records/{recordId}/feedback:
+ *   get:
+ *     summary: Get feedbacks for a specific record (admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: recordId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID of the student record
+ *     responses:
+ *       200:
+ *         description: Feedbacks associated with the specified record
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                     keyword:
+ *                       type: string
+ *                     level:
+ *                       type: string
+ *                     feedbacks:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           title:
+ *                             type: string
+ *                           passage:
+ *                             type: string
+ *                           feedback:
+ *                             type: string
+ *                           _id:
+ *                             type: string
+ *                     userId:
+ *                       type: object
+ *                       properties:
+ *                         _id:
+ *                           type: string
+ *                         name:
+ *                           type: string
+ *                         class_id:
+ *                           type: object
+ *                           properties:
+ *                             _id:
+ *                               type: string
+ *                             class_name:
+ *                               type: string
+ *                             school_name:
+ *                               type: string
+ *       403:
+ *         description: Access denied (not admin)
+ *       404:
+ *         description: Record not found
+ *       500:
+ *         description: Server error
+ */
+router.get('/records/:recordId/feedback', verifyToken, adminController.getFeedbackByRecordController);
+
+
 module.exports = router;

--- a/backend/src/services/text.service.js
+++ b/backend/src/services/text.service.js
@@ -328,19 +328,6 @@ const saveFeedback = async (feedbackData) => {
 };
 
 
-const generateFeedbackData = (keyword, level, feedbacks) => {
-
-  console.log('Feedbacks:', feedbacks);
-
-  const feedbackData = {
-    keyword: keyword,
-    level: level,
-    feedbacks,
-  };
-  return feedbackData;
-};
-
-
 const saveHighlight = async (highlightData) => {
   try {
     const highlight = new Highlight(highlightData);
@@ -475,7 +462,6 @@ module.exports = {
   detectGenerationError,
   testConnection,
   saveFeedback,
-  generateFeedbackData,
   saveHighlight,
   deleteHighlight,
   uploadHighlightImage,

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -85,6 +85,7 @@ const CONFIG = {
     ENDPOINTS: {
       GET_CLASSES: '/classes',
       GET_FEEDBACKS: '/feedbacks',
+      GET_FEEDBACK_BY_RECORD: (recordId) => `/records/${recordId}/feedback`,
     },
   },
 };

--- a/frontend/src/pages/admin/results/AdminResultsOverview.jsx
+++ b/frontend/src/pages/admin/results/AdminResultsOverview.jsx
@@ -156,38 +156,34 @@ const AdminResultsOverview = () => {
                   <th className="score">점수</th>
                 </tr>
               </thead>
-            </table>
 
-            <div className="table-body-wrapper">
-              <table className="learning-results-table">
-                <tbody>
-                  {students.length === 0 ? (
-                    <tr>
-                      <td colSpan="5" style={{ textAlign: 'center', padding: '10px' }}>
-                        선택한 학반에 학생이 없습니다.
+              <tbody>
+                {students.length === 0 ? (
+                  <tr>
+                    <td colSpan="5" style={{ textAlign: 'center', padding: '10px' }}>
+                      선택한 학반에 학생이 없습니다.
+                    </td>
+                  </tr>
+                ) : (
+                  students.map((student, idx) => (
+                    <tr key={student._id}>
+                      <td className="no">{idx + 1}</td>
+                      <td className="school">{student.schoolName}</td>
+                      <td className="class">{student.className}</td>
+                      <td
+                        className="name"
+                        onClick={() => handleStudentClick(student)}
+                      >
+                        🔗 {student.name}
+                      </td>
+                      <td className="score">
+                        {scoreMap[student._id] !== null ? scoreMap[student._id] : 'N/A'}
                       </td>
                     </tr>
-                  ) : (
-                    students.map((student, idx) => (
-                      <tr key={student._id}>
-                        <td className="no">{idx + 1}</td>
-                        <td className="school">{student.schoolName}</td>
-                        <td className="class">{student.className}</td>
-                        <td
-                          className="name"
-                          onClick={() => handleStudentClick(student)}
-                        >
-                          🔗 {student.name}
-                        </td>
-                        <td className="score">
-                          {scoreMap[student._id] !== null ? scoreMap[student._id] : 'N/A'}
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
+                  ))
+                )}
+              </tbody>
+            </table>
           </>
         )}
       </div>

--- a/frontend/src/pages/student/feedback/FeedbackModal.jsx
+++ b/frontend/src/pages/student/feedback/FeedbackModal.jsx
@@ -84,7 +84,11 @@ const FeedbackModal = ({
         },
       );
       console.log('Feedback saved successfully:', response.data);
-      onConfirmSelection(selectedGeneration);
+
+      const savedFeedbackId = response.data.data._id;
+
+      onConfirmSelection(selectedGeneration, savedFeedbackId);
+
     } catch (error) {
       console.error('Error saving feedback:', error);
     }

--- a/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
+++ b/frontend/src/pages/student/keyword-learning/KeywordSolve.jsx
@@ -47,6 +47,7 @@ const KeywordSolve = () => {
 
   const [currentPage, setCurrentPage] = useState(0);
   const [feedbacks, setFeedbacks] = useState([]);
+  const [feedbackId, setFeedbackId] = useState([]);
   const [finalChoiceIndex, setFinalChoiceIndex] = useState(null);
 
   const [selectedGeneration, setSelectedGeneration] = useState(null);
@@ -95,9 +96,10 @@ const KeywordSolve = () => {
     }
   }, []);
 
-  const handleConfirmSelection = (selectedGeneration) => {
+  const handleConfirmSelection = (selectedGeneration, savedFeedbackId) => {
     console.log('selected generation index:', selectedGeneration);
     setSelectedGeneration(selectedGeneration);
+    setFeedbackId(savedFeedbackId);
     setIsModalOpen(false);
     setFeedbackClosedAt(Date.now());
   };
@@ -414,6 +416,7 @@ const KeywordSolve = () => {
           userAnswer: answers,
           elapsedSeconds,
           mode: recordMode,
+          feedbackId,
         },
       );
       console.log('Requested successfully:', response.data);

--- a/frontend/src/pages/student/records/TextDetailModal.jsx
+++ b/frontend/src/pages/student/records/TextDetailModal.jsx
@@ -48,7 +48,14 @@ const formatQuestions = (questions, userAnswers = [], correctAnswers = []) => {
   });
 };
 
-const TextDetailModal = ({ text, record, onClose, onDownload }) => {
+const feedbackLabelMap = {
+  good: '😎 적당해요',
+  too_easy: '😌 너무 쉬워요',
+  too_hard: '😩 너무 어려워요',
+  not_interesting: '😐 흥미롭지 않아요',
+};
+
+const TextDetailModal = ({ text, record, onClose, onDownload, feedbacks = [], isAdmin = false }) => {
   if (!text) return null;
 
   return (
@@ -110,6 +117,22 @@ const TextDetailModal = ({ text, record, onClose, onDownload }) => {
               </p>
             ))}
           </section>
+
+          {isAdmin && feedbacks.length > 0 && (
+            <>
+              <hr />
+              <section>
+                <h2>💬 학생 피드백</h2>
+                {feedbacks.map((fb, i) => (
+                  <div key={fb._id} style={{ marginBottom: '1em' }}>
+                    <h4>{i + 1}. {fb.title}</h4>
+                    <p>{feedbackLabelMap[fb.feedback] || fb.feedback}</p>
+                    <p style={{ whiteSpace: 'pre-line', fontSize: '1rem' }}>{fb.passage}</p>
+                  </div>
+                ))}
+              </section>
+            </>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🔗 Issue

- relates to #128

## 📌 Summary

- ✨ **[DB/BE]** 학습 결과 데이터에서 학생 피드백 데이터를 **참조**하도록 수정

  - 데이터의 흐름을 고려하여, `recordSchema`에서 `feedbackSchema`를 **참조**하도록 함

  - 기존의 **학습 결과 제출 API 수정**하여 피드백 데이터의 Object ID를 처리하도록 함

    - `POST /api/text/answers/verify` (`CHECK_ANSWER`)

  - **[FE]** `FeedbackModal`에서 학생 피드백 제출 시의 object ID를 다음 화면으로 넘김

  - **[FE]** `KeywordSolve`에서 문제 풀이 후 답안 제출 시, 피드백 데이터의 Object ID를 학습 결과 데이터와 함께 저장

  - 학습 결과 데이터의 Object ID(`recordId`)로 학생 피드백 데이터를 조회하는 **관리자 API endpoint 추가**

    - 기존의 API는 피드백을 한꺼번에 모아서 조회할 목적으로 작성되었으므로, 새로운 endpoint 작성

    - `GET /api/admin/records/:recordId/feedback` ⇒ `GET_FEEDBACK_BY_RECORD`

  - 🔗 refs #129

  - 🔗 closes #132

---

- ✨ **[FE]** 관리자 모드의 '**학습 결과 확인**' 화면에 **피드백 데이터** 추가

  - 학습 결과 확인을 위한 공통 component `TextDetailModal` 활용
 
   - **관리자 계정**으로 로그인한 경우에만 **피드백 데이터**가 표시되도록 구현함 (사용자의 **`role`** 확인)

  - 🔗 refs #131

---

#### 🧪 local test completed